### PR TITLE
DM-33783: Don't attempt to parallelize visit definition.

### DIFF
--- a/python/lsst/ci/builder/commands.py
+++ b/python/lsst/ci/builder/commands.py
@@ -84,8 +84,7 @@ class DefineVisits(BaseCommand):
     """
 
     def run(self, currentState: BuildState):
-        defineVisits(self.runner.RunDir, None, self.collectionsName, self.instrumentName,
-                     processes=int(self.arguments.num_cores))
+        defineVisits(self.runner.RunDir, None, self.collectionsName, self.instrumentName)
 
 
 class ButlerImport(BaseCommand):


### PR DESCRIPTION
This was already broken, and is now being removed.