### PR TITLE
DM-34803 Modify clean command to remove RunDir

### DIFF
--- a/python/lsst/ci/builder/ciBuilderLib.py
+++ b/python/lsst/ci/builder/ciBuilderLib.py
@@ -11,6 +11,7 @@ from functools import total_ordering
 import os
 import subprocess
 import sys
+import shutil
 from typing import Iterable, Optional, Tuple, Type
 
 from lsst.log import Log
@@ -217,7 +218,6 @@ class CommandRunner:
         return commandResult
 
     def _init_RunDir(self):
-        self.RunDir = self.args.root
         self.gitCmd = ("git", "-C", self.RunDir, "-c", "user.email='\\<\\>'", "-c", "user.name=ci_builder")
         if not os.path.exists(self.RunDir):
             os.mkdir(self.RunDir)
@@ -260,12 +260,19 @@ class CommandRunner:
 
     def _clean(self):
         """Resets the RunDir to a state before any commands were executed
+
+        By default this just removes the RunDir from the filesystem but the
+        method serves as a hook such that any children can specify alternative
+        behavior.
         """
-        self._runAndTrap(("reset", "--hard", "init"), "There was an issue cleaning the state: {}")
-        allTags = set(self._getAllTags())
-        allTags.remove("init")
-        self._runAndTrap(("tag", "-d") + tuple(allTags), "There was an issue cleaning the state: {}")
-        sys.exit(0)
+        if os.path.isdir(self.RunDir):
+            try:
+                _log.info(f"Removing {self.RunDir}")
+                shutil.rmtree(self.RunDir)
+            except Exception as exc:
+                print(f"There was a problem removing the RunDir:\n {exc}")
+                sys.exit(1)
+            sys.exit(0)
 
     def _reset(self):
         """Resets a RunDir to a given state
@@ -387,6 +394,13 @@ class CommandRunner:
             args = arguments
 
         self.args = args
+        # Record RunDir as early as possible to allow anything below to use the
+        # reference
+        self.RunDir = self.args.root
+
+        # Clean up by removing existing RunDir
+        if args.clean:
+            self._clean()
 
         # list all commands (exits on completion)
         if args.list:
@@ -400,11 +414,6 @@ class CommandRunner:
         # this command to work after RunDir has been init
         if args.status:
             self._print_status()
-
-        # Run clean if requested (exits on completion) must be run after
-        # RunDir init
-        if args.clean:
-            self._clean()
 
         # Reset RunDir to given command (exits on completion)
         if args.reset_target != "":


### PR DESCRIPTION
Change the builtin clean command so that it removes the RunDir, and
move the should clean check earlier. This will prevent the git
repo from growing too large with disconnected refs, as well as
ensure it can be cleaned even if the git repo gets into a broken
state.