### PR TITLE
DM-37571: Disable parallel raw ingest

### DIFF
--- a/python/lsst/ci/builder/commands.py
+++ b/python/lsst/ci/builder/commands.py
@@ -71,8 +71,7 @@ class IngestRaws(BaseCommand):
     """
 
     def run(self, currentState: BuildState):
-        ingestRaws(self.runner.RunDir, (self.rawLocation,), self.FITS_RE, None,
-                   processes=int(self.arguments.num_cores))
+        ingestRaws(self.runner.RunDir, (self.rawLocation,), self.FITS_RE, None)
 
 
 class DefineVisits(BaseCommand):


### PR DESCRIPTION
It doesn't work on MacOS and shouldn't generally be needed in CI packages.