### PR TITLE
DM-46297: override guards against unlabeled curated calibration collections

### DIFF
--- a/python/lsst/ci/builder/commands.py
+++ b/python/lsst/ci/builder/commands.py
@@ -45,7 +45,9 @@ class WriteCuratedCalibrations(BaseCommand):
     """
 
     def run(self, currentState: BuildState):
-        writeCuratedCalibrations(self.runner.RunDir, self.instrumentName, None, tuple())
+        writeCuratedCalibrations(
+            self.runner.RunDir, self.instrumentName, f"{self.instrumentName}/calib", tuple()
+        )
 
 
 class RegisterSkyMap(BaseCommand):


### PR DESCRIPTION
This lets us keep using <instrument>/calib as the name of the calibration collection and hence avoid a lot of churn.